### PR TITLE
Initial merge bot implementation.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -64,5 +64,8 @@
         "semi-spacing": [2, {"before": false, "after": true}],
         "keyword-spacing": 2,
         "space-unary-ops": [2, { "words": true, "nonwords": false }],
+    },
+    "parserOptions": {
+        "ecmaVersion": 2017
     }
 }

--- a/config-example.js
+++ b/config-example.js
@@ -8,6 +8,6 @@
     "owner": "an-owner",
     "dry_run": false,
     "auto_branch": "auto_branch",
-    "checks_number": 1
+    "reviews_number": 1
 }
 

--- a/config-example.js
+++ b/config-example.js
@@ -3,6 +3,11 @@
     "github_token": "generated-token-like-abcder123456",
     "github_webhook_path": "/github-webhook",
     "github_webhook_secret": "shared-git-webhook-secret",
-    "delete_after_merge": true,
     "port": 7777
+    "repo": "a-repo",
+    "owner": "an-owner",
+    "dry_run": false,
+    "auto_branch": "auto_branch",
+    "checks_number": 1
 }
+

--- a/eggtimer.js
+++ b/eggtimer.js
@@ -292,7 +292,7 @@ function deleteCommitComment(params) {
                 return;
             }
             console.log("Deleted commit comment with id " + params.id);
-            resolve(res.data);
+            resolve(true);
         });
   });
 }
@@ -305,7 +305,7 @@ function createCommitComment(params) {
                 reject("Error! Could not create commit comment " + err);
                 return;
             }
-            console.log("Created commit comment", res.data.length, "for sha:", params.ref);
+            console.log("Created commit comment", res.data.id, "for sha:", res.data.commit_id);
             resolve(res.data);
         });
   });
@@ -480,9 +480,9 @@ function finishMerging(prContext) {
             return Promise.all([prPromise, lblPromise, commPromise]);
         })
         .then((results) => {
-            let state = results[0];
-            let labelsUpdated = results[1];
-            let commentDeleted = results[2];
+            const state = results[0];
+            const labelsUpdated = results[1];
+            const commentDeleted = results[2];
             if (state === "closed" && labelsUpdated && commentDeleted)
                 return Promise.resolve(true);
             return Promise.reject("cleanup failed");

--- a/eggtimer.js
+++ b/eggtimer.js
@@ -110,15 +110,11 @@ function allChecksSuccessful(checks) {
 }
 
 function markedAsFailed(labels) {
-    if (labels === undefined)
-        return false;
     return (labels.find((label) => {
            return (label.name === MergeFailedLabel); })) !== undefined;
 }
 
 function markedAsMerged(labels) {
-    if (labels === undefined)
-        return false;
     return (labels.find((label) => {
            return (label.name === MergedLabel); })) !== undefined;
 }
@@ -311,10 +307,10 @@ function checkBeforeStartMerging() {
    console.log(contextToStr(), "looking for previous failed merge attempts");
    getReference(refParams)
        .then( (obj) => {
-           let params = commonParams();
-           params.sha = obj.sha;
+           let commitParams = commonParams();
+           commitParams.sha = obj.sha;
            currentContext.tagSha = obj.sha;
-           let commitPromise = getCommit(params);
+           let commitPromise = getCommit(commitParams);
 
            let prParams = commonParams();
            prParams.number = currentContext.pr.number;
@@ -325,7 +321,7 @@ function checkBeforeStartMerging() {
        .then((results) => {
            let commitObj = results[0];
            let pr = results[1];
-           assert(pr.number = currentContext.pr.number);
+           assert(pr.number === currentContext.pr.number);
            let params = commonParams();
            tagTreeSha = commitObj.treeSha;
            params.ref = "pull/" + currentContext.pr.number + "/merge";

--- a/eggtimer.js
+++ b/eggtimer.js
@@ -312,20 +312,6 @@ function getStatuses(params) {
     });
 }
 
-function getCommit(params) {
-    return new Promise( (resolve, reject) => {
-        Github.authenticate(GithubAuthentication);
-        Github.gitdata.getCommit(params, (err, res) => {
-            if (err) {
-                reject("Error! Could not get commit " + params.sha + ":" + err);
-                return;
-            }
-            console.log("Got commit, sha:", res.data.sha, "treeSha:", res.data.tree.sha);
-            resolve({sha: res.data.sha, treeSha: res.data.tree.sha});
-        });
-  });
-}
-
 function createCommit(params) {
     return new Promise( (resolve, reject) => {
         Github.authenticate(GithubAuthentication);
@@ -398,6 +384,20 @@ function addLabels(params) {
   });
 }
 
+function mergeBranches(params) {
+    return new Promise( (resolve, reject) => {
+        Github.authenticate(GithubAuthentication);
+        Github.repos.merge(params, (err, res) => {
+            if (err) {
+                reject("Error! Could not merge from " + params.head + " to " + params.base + ": ", err);
+                return;
+            }
+            console.log("Merged: got", res.data.sha, "from", res.data.parents[0], "and", res.data.parents[1]);
+            resolve({sha: res.data.sha, treeSha: res.data.tree.sha});
+       });
+    });
+}
+
 function mergeAutoIntoMaster(prContext) {
     let params = prRequestParams();
     assert(prContext.mergedAutoSha);
@@ -466,16 +466,19 @@ function mergePRintoAuto(prContext) {
     getParams.ref = "heads/master";
     let masterSha = null;
     getReference(getParams)
-        .then((sha) => {
-            masterSha = sha;
+         .then((sha) => {
             let params = prRequestParams();
-            params.ref = "pull/" + prContext.pr.number.toString() + "/merge";
-            return getReference(params);
+            params.ref = "heads/" + Config.auto_branch;
+            params.sha = sha;
+            params.force = true;
+            return updateReference(params);
         })
         .then((sha) => {
             let params = prRequestParams();
-            params.sha = sha;
-            return getCommit(params);
+            params.base = Config.auto_branch;
+            params.head = prContext.pr.head.sha;
+            params.message = "Bot merged " + prContext.pr.head.sha + " into " + Config.auto_branch;
+            return mergeBranches(params);
         })
         .then((obj) => {
             let params = prRequestParams();

--- a/eggtimer.js
+++ b/eggtimer.js
@@ -56,6 +56,7 @@ function initContext() {
     assert(currentContext === null);
     currentContext = {};
     let autoSha = null;
+    let mergingCommentId = null;
     let getParams = commonParams();
     getParams.ref = "heads/" + Config.auto_branch;
 
@@ -73,6 +74,7 @@ function initContext() {
                 if (matched) {
                     let params = commonParams();
                     params.number = matched[2];
+                    mergingCommentId = comments[0].id;
                     return getPR(params);
                 }
             }
@@ -81,6 +83,7 @@ function initContext() {
         .then((pr) => {
             currentContext = createPRContext(pr);
             currentContext.autoSha = autoSha;
+            currentContext.commentId = mergingCommentId;
             console.log("Found PR"+ pr.number + " in a merging state");
             finishMerging(currentContext);
             return;
@@ -285,10 +288,10 @@ function deleteCommitComment(params) {
         Github.authenticate(GithubAuthentication);
         Github.repos.deleteCommitComment(params, (err, res) => {
             if (err) {
-                reject("Error! Could not get commit comments" + params.ref + ":" + err);
+                reject("Error! Could not delete comment with id " + params.id + ":" + err);
                 return;
             }
-            console.log("Got commit comments", res.data.length, "for sha:", params.ref);
+            console.log("Deleted commit comment with id " + params.id);
             resolve(res.data);
         });
   });
@@ -313,7 +316,7 @@ function getCommitComments(params) {
         Github.authenticate(GithubAuthentication);
         Github.repos.getCommitComments(params, (err, res) => {
             if (err) {
-                reject("Error! Could not get commit comments" + params.ref + ":" + err);
+                reject("Error! Could not get commit comments " + params.ref + ":" + err);
                 return;
             }
             console.log("Got commit comments", res.data.length, "for sha:", params.ref);

--- a/eggtimer.js
+++ b/eggtimer.js
@@ -353,6 +353,22 @@ function updatePR(params) {
   });
 }
 
+function addLabels(params) {
+   return new Promise( (resolve, reject) => {
+     Github.authenticate(GithubAuthentication);
+     Github.issues.addLabels(params, (err, res) => {
+        if (err) {
+            reject("Error! Could not add label to PR" + params.number + ":" + err);
+            return;
+        }
+        console.log("PR" + params.number.toString(), "labels total:", res.data.length);
+        for (let label of res.data)
+           console.log("PR label name:", label.name);
+        resolve(true);
+     });
+  });
+}
+
 function mergeAutoIntoMaster(prContext) {
     let params = prRequestParams();
     assert(prContext.mergedAutoSha);
@@ -388,6 +404,14 @@ function mergeAutoIntoMaster(prContext) {
         })
         .then((state) => {
              assert(state === null || state === "closed");
+             let labelParams = prRequestParams();
+             labelParams.number = prContext.pr.number.toString();
+             labelParams.labels = [];
+             labelParams.labels.push("S-merged");
+             return addLabels(labelParams);
+         })
+        .then((result) => {
+             assert(result === true);
              processNextPR();
          })
         .catch((err) => {

--- a/eggtimer.js
+++ b/eggtimer.js
@@ -438,21 +438,6 @@ function addLabels(params) {
 
 function finishMerging(prContext) {
 
-    let prParams = commonParams();
-    prParams.state = "closed";
-    prParams.number = prContext.pr.number.toString();
-    let prPromise = updatePR(prParams);
-
-    let labelParams = commonParams();
-    labelParams.number = prContext.pr.number.toString();
-    labelParams.labels = [];
-    labelParams.labels.push("S-merged");
-    let lblPromise = addLabels(labelParams);
-
-    let deleteCommentParams = commonParams();
-    deleteCommentParams.id = prContext.commentId;
-    let commPromise = deleteCommitComment(deleteCommentParams);
-
     let statusParams = commonParams();
     assert(prContext.autoSha);
     statusParams.ref = prContext.autoSha;
@@ -477,6 +462,22 @@ function finishMerging(prContext) {
         })
         .then((sha) => {
             assert(sha === statusParams.ref);
+
+            let prParams = commonParams();
+            prParams.state = "closed";
+            prParams.number = prContext.pr.number.toString();
+            let prPromise = updatePR(prParams);
+
+            let labelParams = commonParams();
+            labelParams.number = prContext.pr.number.toString();
+            labelParams.labels = [];
+            labelParams.labels.push("S-merged");
+            let lblPromise = addLabels(labelParams);
+
+            let deleteCommentParams = commonParams();
+            deleteCommentParams.id = prContext.commentId;
+            let commPromise = deleteCommitComment(deleteCommentParams);
+
             return Promise.all([prPromise, lblPromise, commPromise]);
         })
         .then((results) => {

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "description": "A GitHub webhook target that merges Pull Requests when they're ready",
   "main": "eggtimer.js",
   "dependencies": {
+    "bluebird": "^3.3.4",
     "github": "9.2.0",
-    "parse-github-url": "^0.3.2",
-    "github-webhook-handler": "^0.6.0"
+    "github-webhook-handler": "^0.6.0",
+    "parse-github-url": "^0.3.2"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
PR merging with auto-branch implementation.

This branch fully reworks the initial bot version. Here are some of the ideas it follows to:

* Do not cache any information received from Github, except data used for processing a single PR.

* Do not use received events data, since it is incomplete and requires caching for its processing.

* Use events only as triggers to start polling all available open PRs.

* Use a special 'auto_branch' reference in order to mark being-in-merge commit.
   This commit is created as a merge product of the PR and its base branch (master).

* Merge only one PR at a time, all other PRs should wait until it is successfully merged or failed to 
 merge(e.g., auto_branch checks failed).

* Do all repository manipulations with Github API in order to avoid tricky working with the cloned local copy.

* Automate as much as possible. For example, the bot should itself decide whether to re-try merging previously failed PRs.


